### PR TITLE
Fix timestamp bug

### DIFF
--- a/dist_db/thing.py
+++ b/dist_db/thing.py
@@ -2,7 +2,10 @@ import json
 import time
 
 class Thing:
-    def __init__(self, id, value=None, timestamp=long(time.time() * 1000L)):
+    def __init__(self, id, value=None, timestamp=None):
+        if timestamp is None:
+            timestamp = long(time.time() * 1000L)
+
         self.id = id
         self.value = value
         self.timestamp = timestamp 


### PR DESCRIPTION
Default argument value is only calculated once, so we need to use this idiom to get a fresh timestamp for each newly created `Thing`.
